### PR TITLE
Build v1 Founder OS execution worker (Supabase queue + Codex engine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,76 @@ Shared pre-launch builder system for planning, structuring, and tracking multipl
 
 ## First project
 - AFDP
+
+---
+
+## Execution Worker (v1)
+
+This repo now includes a **minimum working execution worker** that pulls queued build packets from Supabase/Postgres and executes them with Codex.
+
+### What v1 supports
+- `execution_runs` table support
+- Build packet queue polling/claiming
+- Project/task lookup for context
+- Codex-ready prompt generation
+- Branch naming logic (`founder-os/<task-slug>-<id8>`)
+- Validation command execution + tracking
+- Status updates for `build_packets`, `tasks`, and `execution_runs`
+
+### Files
+- Worker: `worker/execution_worker.py`
+- Schema migration: `sql/migrations/20260427_execution_worker.sql`
+
+### Setup
+1. Apply schema in Supabase SQL editor:
+   - `sql/founder_os_schema.sql`
+   - `sql/migrations/20260427_execution_worker.sql`
+2. Install Python dependency:
+   ```bash
+   pip install psycopg[binary]
+   ```
+3. Set environment variables:
+   ```bash
+   export SUPABASE_DB_URL='postgresql://...'
+   export REPO_ROOT='/workspace'
+   # Optional override if your Codex CLI syntax differs
+   export CODEX_EXEC_COMMAND='codex run --prompt-file {prompt_file} --repo {repo_path} --branch {branch}'
+   ```
+
+### Run
+Process one packet and exit:
+```bash
+RUN_ONCE=true python worker/execution_worker.py
+```
+
+Run continuously:
+```bash
+python worker/execution_worker.py
+```
+
+### Packet contract (minimal)
+`build_packets.validation_commands` should be a JSON array of shell commands, for example:
+```json
+["npm test", "npm run lint"]
+```
+
+### Status behavior
+- On claim:
+  - `build_packets.status = running`
+  - `tasks.status = In Progress` (if task-linked)
+- On success:
+  - `build_packets.status = completed`
+  - `execution_runs.status = completed`
+  - `tasks.status = Review`
+- On failure (Codex/validation/unhandled):
+  - `build_packets.status = failed`
+  - `execution_runs.status = failed` (if run was created)
+  - `tasks.status = Blocked`
+
+### Validation steps (local)
+```bash
+python -m py_compile worker/execution_worker.py
+RUN_ONCE=true python worker/execution_worker.py
+```
+
+The second command requires `SUPABASE_DB_URL` and a reachable database.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This repo now includes a **minimum working execution worker** that pulls queued 
    ```bash
    export SUPABASE_DB_URL='postgresql://...'
    export REPO_ROOT='/workspace'
+   export COMMAND_TIMEOUT_SECONDS='1800'
    # Optional override if your Codex CLI syntax differs
    export CODEX_EXEC_COMMAND='codex run --prompt-file {prompt_file} --repo {repo_path} --branch {branch}'
    ```
@@ -88,3 +89,13 @@ RUN_ONCE=true python worker/execution_worker.py
 ```
 
 The second command requires `SUPABASE_DB_URL` and a reachable database.
+
+### Quick smoke test (recommended)
+1. Seed a packet with `worker/smoke_test.sql` (replace placeholder IDs/paths first).
+2. Run worker once:
+   ```bash
+   RUN_ONCE=true python worker/execution_worker.py
+   ```
+3. Re-run the status queries from `worker/smoke_test.sql` and confirm:
+   - `build_packets.status` moved from `queued` to `completed` or `failed`
+   - one `execution_runs` row exists for that packet

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ python worker/execution_worker.py
 ["npm test", "npm run lint"]
 ```
 
+Contract checks performed by worker before execution:
+- Required fields: `id`, `project_id`, `packet_title`, `packet_body`, `target_repo`, `base_branch`
+- `validation_commands` must be a JSON array of strings
+- `target_repo` must resolve inside `REPO_ROOT` and exist on disk
+
 ### Status behavior
 - On claim:
   - `build_packets.status = running`

--- a/sql/migrations/20260427_execution_worker.sql
+++ b/sql/migrations/20260427_execution_worker.sql
@@ -1,0 +1,40 @@
+-- Founder OS Execution Worker baseline schema
+
+create table if not exists build_packets (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references projects(id) on delete cascade,
+  task_id uuid references tasks(id) on delete set null,
+  packet_title text not null,
+  packet_body text not null,
+  target_repo text not null,
+  base_branch text not null default 'main',
+  status text not null default 'queued', -- queued | running | completed | failed
+  queued_at timestamptz not null default now(),
+  started_at timestamptz,
+  completed_at timestamptz,
+  codex_branch text,
+  validation_commands jsonb not null default '[]'::jsonb,
+  last_error text
+);
+
+create table if not exists execution_runs (
+  id uuid primary key default gen_random_uuid(),
+  build_packet_id uuid not null references build_packets(id) on delete cascade,
+  project_id uuid not null references projects(id) on delete cascade,
+  task_id uuid references tasks(id) on delete set null,
+  status text not null default 'running', -- running | completed | failed
+  codex_prompt text not null,
+  codex_branch text not null,
+  codex_stdout text,
+  codex_stderr text,
+  codex_exit_code int,
+  validation_results jsonb not null default '[]'::jsonb,
+  started_at timestamptz not null default now(),
+  finished_at timestamptz
+);
+
+create index if not exists idx_build_packets_status_queued_at
+  on build_packets(status, queued_at);
+
+create index if not exists idx_execution_runs_build_packet_id
+  on execution_runs(build_packet_id);

--- a/worker/execution_worker.py
+++ b/worker/execution_worker.py
@@ -21,6 +21,7 @@ import tempfile
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from uuid import UUID
 
@@ -34,6 +35,10 @@ class WorkerConfig:
     poll_seconds: int = 10
     codex_exec_command: str = "codex run --prompt-file {prompt_file} --repo {repo_path} --branch {branch}"
     repo_root: str = "/workspace"
+
+
+class PacketValidationError(ValueError):
+    """Raised when a queued build packet does not meet the worker contract."""
 
 
 def utc_now() -> datetime:
@@ -105,6 +110,39 @@ def run_codex(codex_template: str, prompt: str, repo_path: str, branch: str) -> 
         return run_command(command, cwd=repo_path)
     finally:
         os.unlink(prompt_file)
+
+
+def validate_packet(packet: dict[str, Any]) -> None:
+    required = ["id", "project_id", "packet_title", "packet_body", "target_repo", "base_branch"]
+    missing = [key for key in required if not packet.get(key)]
+    if missing:
+        raise PacketValidationError(f"Missing required packet fields: {', '.join(missing)}")
+
+
+def parse_validation_commands(raw_commands: Any) -> list[str]:
+    if raw_commands is None:
+        return []
+    commands = raw_commands
+    if isinstance(raw_commands, str):
+        try:
+            commands = json.loads(raw_commands)
+        except json.JSONDecodeError as exc:
+            raise PacketValidationError(f"validation_commands is not valid JSON: {exc}") from exc
+    if not isinstance(commands, list) or any(not isinstance(item, str) for item in commands):
+        raise PacketValidationError("validation_commands must be a JSON array of command strings")
+    return commands
+
+
+def resolve_repo_path(repo_root: str, target_repo: str) -> str:
+    candidate = (Path(repo_root) / target_repo).resolve()
+    root = Path(repo_root).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise PacketValidationError("target_repo must stay within REPO_ROOT") from exc
+    if not candidate.exists():
+        raise PacketValidationError(f"target_repo path does not exist: {candidate}")
+    return str(candidate)
 
 
 def fetch_one_queued_packet(conn: psycopg.Connection[Any]) -> dict[str, Any] | None:
@@ -287,18 +325,17 @@ def process_one_packet(config: WorkerConfig) -> bool:
 
         run_id: UUID | None = None
         try:
+            validate_packet(packet)
             project, task = get_project_and_task(conn, packet)
             branch = build_branch_name(task, packet)
             prompt = build_codex_prompt(packet, project, task, branch)
             run_id = create_execution_run(conn, packet, branch, prompt)
             conn.commit()
 
-            repo_path = os.path.join(config.repo_root, packet["target_repo"])
+            repo_path = resolve_repo_path(config.repo_root, packet["target_repo"])
             codex_code, codex_out, codex_err = run_codex(config.codex_exec_command, prompt, repo_path, branch)
 
-            commands = packet.get("validation_commands") or []
-            if isinstance(commands, str):
-                commands = json.loads(commands)
+            commands = parse_validation_commands(packet.get("validation_commands"))
             validation_results = run_validation_commands(commands, cwd=repo_path)
             validations_ok = all(item["passed"] for item in validation_results)
 

--- a/worker/execution_worker.py
+++ b/worker/execution_worker.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Founder OS execution worker (minimum viable version).
+
+Flow:
+1) claim one queued build packet
+2) lookup project/task context
+3) generate Codex prompt + branch name
+4) execute Codex command
+5) run validation commands
+6) update build_packets, tasks, execution_runs statuses
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+import psycopg
+from psycopg.rows import dict_row
+
+
+@dataclass
+class WorkerConfig:
+    db_url: str
+    poll_seconds: int = 10
+    codex_exec_command: str = "codex run --prompt-file {prompt_file} --repo {repo_path} --branch {branch}"
+    repo_root: str = "/workspace"
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def sanitize_slug(value: str, max_len: int = 40) -> str:
+    normalized = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip().lower()).strip("-")
+    return normalized[:max_len] or "task"
+
+
+def build_branch_name(task: dict[str, Any] | None, packet: dict[str, Any]) -> str:
+    task_part = "task"
+    if task:
+        task_part = sanitize_slug(task.get("task_title") or "task")
+        task_id = str(task["id"])[:8]
+    else:
+        task_id = str(packet["id"])[:8]
+    return f"founder-os/{task_part}-{task_id}"
+
+
+def build_codex_prompt(packet: dict[str, Any], project: dict[str, Any], task: dict[str, Any] | None, branch: str) -> str:
+    task_block = ""
+    if task:
+        task_block = (
+            f"Task Title: {task['task_title']}\n"
+            f"Task Description: {task.get('description') or 'N/A'}\n"
+            f"Task Type: {task.get('task_type') or 'N/A'}\n"
+        )
+
+    return (
+        "You are Codex acting as Founder OS execution engine.\n"
+        "Implement only what is requested in the build packet with minimal changes.\n"
+        "Do not add infrastructure not explicitly requested.\n\n"
+        f"Project: {project['project_name']}\n"
+        f"Project Summary: {project.get('summary') or 'N/A'}\n"
+        f"Target Repo: {packet['target_repo']}\n"
+        f"Base Branch: {packet['base_branch']}\n"
+        f"Execution Branch: {branch}\n\n"
+        f"Build Packet Title: {packet['packet_title']}\n"
+        f"Build Packet Body:\n{packet['packet_body']}\n\n"
+        f"{task_block}"
+        "After making changes, run requested validations, commit, and prepare PR output.\n"
+    )
+
+
+def run_command(command: str, cwd: str) -> tuple[int, str, str]:
+    process = subprocess.run(
+        command,
+        cwd=cwd,
+        shell=True,
+        text=True,
+        capture_output=True,
+    )
+    return process.returncode, process.stdout, process.stderr
+
+
+def run_codex(codex_template: str, prompt: str, repo_path: str, branch: str) -> tuple[int, str, str]:
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+        f.write(prompt)
+        prompt_file = f.name
+
+    try:
+        command = codex_template.format(
+            prompt_file=shlex.quote(prompt_file),
+            repo_path=shlex.quote(repo_path),
+            branch=shlex.quote(branch),
+        )
+        return run_command(command, cwd=repo_path)
+    finally:
+        os.unlink(prompt_file)
+
+
+def fetch_one_queued_packet(conn: psycopg.Connection[Any]) -> dict[str, Any] | None:
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """
+            select *
+            from build_packets
+            where status = 'queued'
+            order by queued_at asc
+            for update skip locked
+            limit 1
+            """
+        )
+        return cur.fetchone()
+
+
+def claim_packet(conn: psycopg.Connection[Any], packet_id: UUID) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            update build_packets
+               set status = 'running',
+                   started_at = %s,
+                   last_error = null
+             where id = %s
+            """,
+            (utc_now(), packet_id),
+        )
+
+
+def get_project_and_task(conn: psycopg.Connection[Any], packet: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute("select * from projects where id = %s", (packet["project_id"],))
+        project = cur.fetchone()
+        if not project:
+            raise ValueError(f"Project not found: {packet['project_id']}")
+
+        task = None
+        if packet.get("task_id"):
+            cur.execute("select * from tasks where id = %s", (packet["task_id"],))
+            task = cur.fetchone()
+        return project, task
+
+
+def create_execution_run(
+    conn: psycopg.Connection[Any],
+    packet: dict[str, Any],
+    branch: str,
+    prompt: str,
+) -> UUID:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            insert into execution_runs (build_packet_id, project_id, task_id, status, codex_prompt, codex_branch)
+            values (%s, %s, %s, 'running', %s, %s)
+            returning id
+            """,
+            (packet["id"], packet["project_id"], packet.get("task_id"), prompt, branch),
+        )
+        row = cur.fetchone()
+        return row[0]
+
+
+def update_task_status(conn: psycopg.Connection[Any], task_id: UUID | None, status: str) -> None:
+    if not task_id:
+        return
+    with conn.cursor() as cur:
+        cur.execute("update tasks set status = %s where id = %s", (status, task_id))
+
+
+def finalize_success(
+    conn: psycopg.Connection[Any],
+    packet_id: UUID,
+    run_id: UUID,
+    branch: str,
+    codex_out: str,
+    codex_err: str,
+    codex_code: int,
+    validation_results: list[dict[str, Any]],
+) -> None:
+    finished_at = utc_now()
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            update build_packets
+               set status = 'completed',
+                   completed_at = %s,
+                   codex_branch = %s
+             where id = %s
+            """,
+            (finished_at, branch, packet_id),
+        )
+        cur.execute(
+            """
+            update execution_runs
+               set status = 'completed',
+                   finished_at = %s,
+                   codex_stdout = %s,
+                   codex_stderr = %s,
+                   codex_exit_code = %s,
+                   validation_results = %s
+             where id = %s
+            """,
+            (finished_at, codex_out, codex_err, codex_code, json.dumps(validation_results), run_id),
+        )
+
+
+def finalize_failure(
+    conn: psycopg.Connection[Any],
+    packet_id: UUID,
+    run_id: UUID,
+    err: str,
+    codex_out: str = "",
+    codex_err: str = "",
+    codex_code: int | None = None,
+    validation_results: list[dict[str, Any]] | None = None,
+) -> None:
+    finished_at = utc_now()
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            update build_packets
+               set status = 'failed',
+                   completed_at = %s,
+                   last_error = %s
+             where id = %s
+            """,
+            (finished_at, err[:4000], packet_id),
+        )
+        cur.execute(
+            """
+            update execution_runs
+               set status = 'failed',
+                   finished_at = %s,
+                   codex_stdout = %s,
+                   codex_stderr = %s,
+                   codex_exit_code = %s,
+                   validation_results = %s
+             where id = %s
+            """,
+            (
+                finished_at,
+                codex_out,
+                codex_err,
+                codex_code,
+                json.dumps(validation_results or []),
+                run_id,
+            ),
+        )
+
+
+def run_validation_commands(commands: list[str], cwd: str) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for cmd in commands:
+        code, out, err = run_command(cmd, cwd)
+        results.append(
+            {
+                "command": cmd,
+                "exit_code": code,
+                "stdout": out,
+                "stderr": err,
+                "passed": code == 0,
+            }
+        )
+    return results
+
+
+def process_one_packet(config: WorkerConfig) -> bool:
+    with psycopg.connect(config.db_url) as conn:
+        conn.autocommit = False
+        packet = fetch_one_queued_packet(conn)
+        if not packet:
+            conn.commit()
+            return False
+
+        claim_packet(conn, packet["id"])
+        update_task_status(conn, packet.get("task_id"), "In Progress")
+        conn.commit()
+
+        run_id: UUID | None = None
+        try:
+            project, task = get_project_and_task(conn, packet)
+            branch = build_branch_name(task, packet)
+            prompt = build_codex_prompt(packet, project, task, branch)
+            run_id = create_execution_run(conn, packet, branch, prompt)
+            conn.commit()
+
+            repo_path = os.path.join(config.repo_root, packet["target_repo"])
+            codex_code, codex_out, codex_err = run_codex(config.codex_exec_command, prompt, repo_path, branch)
+
+            commands = packet.get("validation_commands") or []
+            if isinstance(commands, str):
+                commands = json.loads(commands)
+            validation_results = run_validation_commands(commands, cwd=repo_path)
+            validations_ok = all(item["passed"] for item in validation_results)
+
+            if codex_code == 0 and validations_ok:
+                finalize_success(conn, packet["id"], run_id, branch, codex_out, codex_err, codex_code, validation_results)
+                update_task_status(conn, packet.get("task_id"), "Review")
+            else:
+                reason = "Codex execution failed" if codex_code != 0 else "Validation commands failed"
+                finalize_failure(
+                    conn,
+                    packet["id"],
+                    run_id,
+                    err=reason,
+                    codex_out=codex_out,
+                    codex_err=codex_err,
+                    codex_code=codex_code,
+                    validation_results=validation_results,
+                )
+                update_task_status(conn, packet.get("task_id"), "Blocked")
+
+            conn.commit()
+            return True
+        except Exception as exc:  # noqa: BLE001
+            if run_id:
+                finalize_failure(conn, packet["id"], run_id, err=f"Unhandled worker error: {exc}")
+                update_task_status(conn, packet.get("task_id"), "Blocked")
+                conn.commit()
+            else:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "update build_packets set status = 'failed', last_error = %s where id = %s",
+                        (f"Worker setup failure: {exc}"[:4000], packet["id"]),
+                    )
+                    update_task_status(conn, packet.get("task_id"), "Blocked")
+                conn.commit()
+            return True
+
+
+def main() -> None:
+    db_url = os.environ.get("SUPABASE_DB_URL")
+    if not db_url:
+        raise SystemExit("SUPABASE_DB_URL is required")
+
+    config = WorkerConfig(
+        db_url=db_url,
+        poll_seconds=int(os.environ.get("WORKER_POLL_SECONDS", "10")),
+        codex_exec_command=os.environ.get(
+            "CODEX_EXEC_COMMAND",
+            "codex run --prompt-file {prompt_file} --repo {repo_path} --branch {branch}",
+        ),
+        repo_root=os.environ.get("REPO_ROOT", "/workspace"),
+    )
+
+    run_once = os.environ.get("RUN_ONCE", "false").lower() == "true"
+    while True:
+        handled = process_one_packet(config)
+        if run_once:
+            return
+        if not handled:
+            time.sleep(config.poll_seconds)
+
+
+if __name__ == "__main__":
+    main()

--- a/worker/execution_worker.py
+++ b/worker/execution_worker.py
@@ -35,6 +35,7 @@ class WorkerConfig:
     poll_seconds: int = 10
     codex_exec_command: str = "codex run --prompt-file {prompt_file} --repo {repo_path} --branch {branch}"
     repo_root: str = "/workspace"
+    command_timeout_seconds: int = 1800
 
 
 class PacketValidationError(ValueError):
@@ -85,18 +86,32 @@ def build_codex_prompt(packet: dict[str, Any], project: dict[str, Any], task: di
     )
 
 
-def run_command(command: str, cwd: str) -> tuple[int, str, str]:
-    process = subprocess.run(
-        command,
-        cwd=cwd,
-        shell=True,
-        text=True,
-        capture_output=True,
-    )
-    return process.returncode, process.stdout, process.stderr
+def run_command(command: str, cwd: str, timeout_seconds: int) -> tuple[int, str, str]:
+    try:
+        process = subprocess.run(
+            command,
+            cwd=cwd,
+            shell=True,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+        )
+        return process.returncode, process.stdout, process.stderr
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        timeout_msg = f"Command timed out after {timeout_seconds}s"
+        stderr = f"{stderr}\n{timeout_msg}".strip()
+        return 124, stdout, stderr
 
 
-def run_codex(codex_template: str, prompt: str, repo_path: str, branch: str) -> tuple[int, str, str]:
+def run_codex(
+    codex_template: str,
+    prompt: str,
+    repo_path: str,
+    branch: str,
+    timeout_seconds: int,
+) -> tuple[int, str, str]:
     with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
         f.write(prompt)
         prompt_file = f.name
@@ -107,7 +122,7 @@ def run_codex(codex_template: str, prompt: str, repo_path: str, branch: str) -> 
             repo_path=shlex.quote(repo_path),
             branch=shlex.quote(branch),
         )
-        return run_command(command, cwd=repo_path)
+        return run_command(command, cwd=repo_path, timeout_seconds=timeout_seconds)
     finally:
         os.unlink(prompt_file)
 
@@ -295,10 +310,10 @@ def finalize_failure(
         )
 
 
-def run_validation_commands(commands: list[str], cwd: str) -> list[dict[str, Any]]:
+def run_validation_commands(commands: list[str], cwd: str, timeout_seconds: int) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
     for cmd in commands:
-        code, out, err = run_command(cmd, cwd)
+        code, out, err = run_command(cmd, cwd, timeout_seconds=timeout_seconds)
         results.append(
             {
                 "command": cmd,
@@ -333,10 +348,20 @@ def process_one_packet(config: WorkerConfig) -> bool:
             conn.commit()
 
             repo_path = resolve_repo_path(config.repo_root, packet["target_repo"])
-            codex_code, codex_out, codex_err = run_codex(config.codex_exec_command, prompt, repo_path, branch)
+            codex_code, codex_out, codex_err = run_codex(
+                config.codex_exec_command,
+                prompt,
+                repo_path,
+                branch,
+                timeout_seconds=config.command_timeout_seconds,
+            )
 
             commands = parse_validation_commands(packet.get("validation_commands"))
-            validation_results = run_validation_commands(commands, cwd=repo_path)
+            validation_results = run_validation_commands(
+                commands,
+                cwd=repo_path,
+                timeout_seconds=config.command_timeout_seconds,
+            )
             validations_ok = all(item["passed"] for item in validation_results)
 
             if codex_code == 0 and validations_ok:
@@ -387,6 +412,7 @@ def main() -> None:
             "codex run --prompt-file {prompt_file} --repo {repo_path} --branch {branch}",
         ),
         repo_root=os.environ.get("REPO_ROOT", "/workspace"),
+        command_timeout_seconds=int(os.environ.get("COMMAND_TIMEOUT_SECONDS", "1800")),
     )
 
     run_once = os.environ.get("RUN_ONCE", "false").lower() == "true"

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -1,0 +1,1 @@
+psycopg[binary]>=3.2

--- a/worker/smoke_test.sql
+++ b/worker/smoke_test.sql
@@ -1,0 +1,39 @@
+-- Founder OS worker smoke test
+-- Replace IDs and repo path placeholders before running.
+
+-- 1) ensure a task exists for the project (optional)
+-- insert into tasks (project_id, task_title, description, status)
+-- values ('<project_uuid>', 'Smoke test execution task', 'Validate worker end-to-end', 'New')
+-- returning id;
+
+-- 2) enqueue one packet
+insert into build_packets (
+  project_id,
+  task_id,
+  packet_title,
+  packet_body,
+  target_repo,
+  base_branch,
+  validation_commands
+) values (
+  '<project_uuid>',
+  null,
+  'Smoke test packet',
+  'Create or update a small README note so we can validate execution flow.',
+  '<repo-folder-under-REPO_ROOT>',
+  'main',
+  '["git status --short"]'::jsonb
+)
+returning id, status, queued_at;
+
+-- 3) watch queue state
+select id, status, started_at, completed_at, codex_branch, last_error
+from build_packets
+order by queued_at desc
+limit 5;
+
+-- 4) inspect execution run details
+select id, build_packet_id, status, codex_exit_code, started_at, finished_at
+from execution_runs
+order by started_at desc
+limit 5;


### PR DESCRIPTION
### Motivation
- Provide a minimal, runnable execution worker that can pull queued build packets from Supabase/Postgres and use Codex to apply requested changes to a repository. 
- Track execution lifecycle and validations so UIs and automation can observe `build_packets` and `execution_runs` statuses.

### Description
- Add SQL migration `sql/migrations/20260427_execution_worker.sql` to create `build_packets` and `execution_runs` tables and supporting indexes. 
- Add `worker/execution_worker.py` implementing queue polling/claim, `projects`/`tasks` lookup, Codex prompt generation, branch naming (`founder-os/<task-slug>-<id8>`), execution via a configurable Codex CLI template, validation command execution, and status transitions. 
- Add `worker/requirements.txt` declaring `psycopg[binary]` and update `README.md` with setup, run instructions, packet contract, and status behavior. 

### Testing
- `python -m py_compile worker/execution_worker.py` completed successfully. 
- Running `RUN_ONCE=true python worker/execution_worker.py` failed in this environment because the `psycopg` dependency is not installed. 
- Attempted `pip install psycopg[binary]` in the environment failed due to network/proxy restrictions, so runtime integration against a Supabase DB was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb76e132083318ed5dbc676e97317)