### PR TITLE
Add execution worker and packet coordinator with DB migrations and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: queue-approved-tasks worker-once worker-loop test-worker
+
+queue-approved-tasks:
+	python worker/packet_coordinator.py
+
+worker-once:
+	RUN_ONCE=true python worker/execution_worker.py
+
+worker-loop:
+	python worker/execution_worker.py
+
+test-worker:
+	python -m unittest worker/test_execution_worker.py worker/test_packet_coordinator.py

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: preflight queue-approved-tasks worker-once worker-loop test-worker
+.PHONY: preflight migrate queue-approved-tasks worker-once worker-loop test-worker
 
 preflight:
 	python worker/live_gate_preflight.py
+
+migrate:
+	python worker/apply_migrations.py
 
 queue-approved-tasks:
 	python worker/packet_coordinator.py

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: queue-approved-tasks worker-once worker-loop test-worker
+.PHONY: preflight queue-approved-tasks worker-once worker-loop test-worker
+
+preflight:
+	python worker/live_gate_preflight.py
 
 queue-approved-tasks:
 	python worker/packet_coordinator.py

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Run preflight checks (DB reachability, repo paths, codex/git binaries):
 make preflight
 ```
 
+Apply all SQL migrations in order:
+```bash
+make migrate
+```
+
 Process one packet and exit:
 ```bash
 RUN_ONCE=true python worker/execution_worker.py
@@ -174,6 +179,8 @@ The second command requires `SUPABASE_DB_URL` and a reachable database.
 - `Network is unreachable` when connecting to Supabase:
   - this often means your runtime cannot reach IPv6-only DB endpoints.
   - use Supabase pooler/connection settings that provide IPv4 connectivity for server-side workers.
+- `database URL still contains a password placeholder`:
+  - replace `[YOUR-PASSWORD]` / `<password>` with a real credential before running preflight.
 - Repo path not found:
   - verify `REPO_ROOT` points to a real path in the runtime where the worker executes.
   - if using multiple repos, set `REPO_MAP_JSON` with absolute reachable paths.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Database constraints enforce:
   - Compatible approval models:
     - `tasks.approved = true` (legacy/current)
     - `tasks.review_status = approved` (new migration model)
+    - `tasks.execution_status in ('Queued','Approved')` (legacy queue model)
   - approved task + `build_packet_id is null` → coordinator creates `build_packets` row
   - `tasks.build_packet_id` and `tasks.packet_generated_at` are populated
   - `tasks.status = Queued`

--- a/README.md
+++ b/README.md
@@ -10,3 +10,156 @@ Shared pre-launch builder system for planning, structuring, and tracking multipl
 
 ## First project
 - AFDP
+
+---
+
+## Execution Worker (v1)
+
+This repo now includes a **minimum working execution worker** that pulls queued build packets from Supabase/Postgres and executes them with Codex.
+
+### What v1 supports
+- `execution_runs` table support
+- Build packet queue polling/claiming
+- Approved-task → build-packet queue coordination
+- Project/task lookup for context
+- Codex-ready prompt generation
+- Branch naming logic (`founder-os/<task-slug>-<id8>`)
+- Validation command execution + tracking
+- Status updates for `build_packets`, `tasks`, and `execution_runs`
+
+### Files
+- Worker: `worker/execution_worker.py`
+- Coordinator: `worker/packet_coordinator.py`
+- Schema migration: `sql/migrations/20260427_execution_worker.sql`
+
+### Setup
+1. Apply schema in Supabase SQL editor:
+   - `sql/founder_os_schema.sql`
+   - `sql/migrations/20260427_execution_worker.sql`
+   - `sql/migrations/20260427_execution_worker_retries.sql` (safe to run on existing installs)
+   - `sql/migrations/20260427_execution_worker_failure_codes.sql` (safe to run on existing installs)
+   - `sql/migrations/20260427_execution_worker_constraints.sql` (safe to run on existing installs)
+   - `sql/migrations/20260427_task_review_and_packet_link.sql` (task approval + packet link flow)
+   - `sql/migrations/20260428_execution_worker_outputs.sql` (commit/PR output tracking)
+2. Install Python dependency:
+   ```bash
+   pip install psycopg[binary]
+   ```
+3. Set environment variables:
+   ```bash
+   export SUPABASE_DB_URL='postgresql://...'
+   export REPO_ROOT='/workspace'  # or absolute repo path in single-repo mode
+   export REPO_MAP_JSON='{"AFDP":"/Users/jojo/Developer/african-food-discovery-platform"}'
+   export COMMAND_TIMEOUT_SECONDS='1800'
+   export CODEX_RESULT_JSON_RELPATH='.founder_os/execution_result.json'
+   # Optional: either a template string or plain command (e.g. CODEX_EXEC_COMMAND=codex)
+   export CODEX_EXEC_COMMAND='codex run --prompt-file {prompt_file} --repo {repo_path} --branch {branch}'
+   # Optional: JSON array OR newline-delimited commands
+   export DEFAULT_VALIDATION_COMMANDS='["npm install","npm run lint","npm run build"]'
+   ```
+
+### Run
+Queue approved tasks into `build_packets`:
+```bash
+python worker/packet_coordinator.py
+```
+
+Process one packet and exit:
+```bash
+RUN_ONCE=true python worker/execution_worker.py
+```
+
+Run continuously:
+```bash
+python worker/execution_worker.py
+```
+
+Or use Make targets:
+```bash
+make queue-approved-tasks
+make worker-once
+make worker-loop
+```
+
+### Packet contract (minimal)
+`build_packets.validation_commands` should be a JSON array of shell commands, for example:
+```json
+["npm test", "npm run lint"]
+```
+
+Contract checks performed by worker before execution:
+- Required fields: `id`, `project_id`, `packet_title`, `packet_body`, `target_repo`, `base_branch`
+- `validation_commands` must be a JSON array of strings
+- `validation_commands` cannot contain blank commands
+- `target_repo` must resolve inside `REPO_ROOT` and exist on disk
+
+Database constraints enforce:
+- valid packet/run statuses only
+- `attempts >= 0`
+- `max_attempts >= 1`
+
+### Status behavior
+- Task approval to queue:
+  - Compatible approval models:
+    - `tasks.approved = true` (legacy/current)
+    - `tasks.review_status = approved` (new migration model)
+  - approved task + `build_packet_id is null` → coordinator creates `build_packets` row
+  - `tasks.build_packet_id` and `tasks.packet_generated_at` are populated
+  - `tasks.status = Queued`
+- On claim:
+  - `build_packets.status = running`
+  - `tasks.status = In Progress` (if task-linked)
+- On success:
+  - `build_packets.status = completed`
+  - `execution_runs.status = completed`
+  - `execution_runs.commit_sha`, `execution_runs.pr_url`, `execution_runs.pr_number` captured when provided by Codex output file
+  - `tasks.status = Review`
+- On failed attempt (before max attempts):
+  - `build_packets.status = queued` (re-queued)
+  - `build_packets.last_error_code` captures machine-readable failure reason
+  - `build_packets.last_error` records the failure reason
+  - `execution_runs.status = failed` (if run was created for that attempt)
+  - `execution_runs.failure_code` captures machine-readable failure reason
+- On terminal failure (max attempts reached):
+  - `build_packets.status = failed`
+  - `execution_runs.status = failed` (if run was created)
+  - `tasks.status = Blocked`
+
+Failure codes currently emitted by the worker:
+- `missing_project`
+- `missing_task`
+- `invalid_packet`
+- `invalid_repo_path`
+- `codex_nonzero`
+- `validation_nonzero`
+- `unhandled_worker_error`
+
+Codex output contract:
+- Worker asks Codex to write `.founder_os/execution_result.json` in the target repo.
+- JSON keys consumed by worker: `branch`, `commit_sha`, `pr_url`, `pr_number`.
+
+### Validation steps (local)
+```bash
+python -m py_compile worker/execution_worker.py
+python -m py_compile worker/packet_coordinator.py
+python -m unittest worker/test_execution_worker.py
+python -m unittest worker/test_packet_coordinator.py
+RUN_ONCE=true python worker/execution_worker.py
+```
+
+The second command requires `SUPABASE_DB_URL` and a reachable database.
+
+### Quick smoke test (recommended)
+1. Seed a packet with `worker/smoke_test.sql` (replace placeholder IDs/paths first).
+2. Run worker once:
+   ```bash
+   RUN_ONCE=true python worker/execution_worker.py
+   ```
+3. Re-run the status queries from `worker/smoke_test.sql` and confirm:
+   - `build_packets.status` moved from `queued` to `completed` or `failed`
+   - one `execution_runs` row exists for that packet
+
+### Retry behavior
+- Each packet tracks `attempts` and `max_attempts` (`max_attempts` defaults to `3`).
+- On failure before max attempts, packet is re-queued (`status = queued`) for another try.
+- Once max attempts is reached, packet is marked `failed` and task is marked `Blocked`.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ Queue approved tasks into `build_packets`:
 python worker/packet_coordinator.py
 ```
 
+Run preflight checks (DB reachability, repo paths, codex/git binaries):
+```bash
+make preflight
+```
+
 Process one packet and exit:
 ```bash
 RUN_ONCE=true python worker/execution_worker.py
@@ -164,3 +169,11 @@ The second command requires `SUPABASE_DB_URL` and a reachable database.
 - Each packet tracks `attempts` and `max_attempts` (`max_attempts` defaults to `3`).
 - On failure before max attempts, packet is re-queued (`status = queued`) for another try.
 - Once max attempts is reached, packet is marked `failed` and task is marked `Blocked`.
+
+### Troubleshooting
+- `Network is unreachable` when connecting to Supabase:
+  - this often means your runtime cannot reach IPv6-only DB endpoints.
+  - use Supabase pooler/connection settings that provide IPv4 connectivity for server-side workers.
+- Repo path not found:
+  - verify `REPO_ROOT` points to a real path in the runtime where the worker executes.
+  - if using multiple repos, set `REPO_MAP_JSON` with absolute reachable paths.

--- a/README.md
+++ b/README.md
@@ -177,3 +177,5 @@ The second command requires `SUPABASE_DB_URL` and a reachable database.
 - Repo path not found:
   - verify `REPO_ROOT` points to a real path in the runtime where the worker executes.
   - if using multiple repos, set `REPO_MAP_JSON` with absolute reachable paths.
+
+For a full live unblock checklist, use: `docs/live-gate-fix-plan.md`.

--- a/docs/live-gate-fix-plan.md
+++ b/docs/live-gate-fix-plan.md
@@ -1,0 +1,82 @@
+# Founder OS Live Gate Fix Plan
+
+This runbook focuses on unblocking the three current blockers seen by preflight:
+
+1. Supabase DB connectivity (`Network is unreachable`)
+2. Repo path accessibility
+3. Codex binary availability
+
+## 1) Fix Supabase DB connectivity
+
+If you see `Network is unreachable` to the `db.<ref>.supabase.co` host, your runtime likely cannot route IPv6.
+
+### Use an IPv4-capable connection string
+- In Supabase Dashboard, open **Project Settings → Database → Connection string**.
+- Prefer a **pooler** host that supports IPv4 in your runtime.
+- Set:
+
+```bash
+export SUPABASE_DB_URL='postgresql://<user>:<password>@<pooler-host>:6543/postgres?sslmode=require'
+```
+
+### Validate connection
+```bash
+make preflight
+```
+
+## 2) Fix repo path accessibility
+
+The worker must run where the target repo path exists.
+
+### Option A (recommended): run on your machine
+Use your local path directly:
+
+```bash
+export REPO_ROOT='/Users/jojo/Developer/african-food-discovery-platform'
+export DEFAULT_TARGET_REPO='AFDP'
+export REPO_MAP_JSON='{"AFDP":"/Users/jojo/Developer/african-food-discovery-platform"}'
+```
+
+### Option B: run in container/CI
+Mount repo(s) into runtime and point `REPO_ROOT`/`REPO_MAP_JSON` to mounted paths.
+
+## 3) Fix Codex binary availability
+
+Install Codex CLI in the same environment running worker/coordinator.
+
+### Validate binary
+```bash
+which codex
+make preflight
+```
+
+## 4) Queue and execute one real task
+
+Use one real task row with a valid project link.
+
+```bash
+export DEFAULT_VALIDATION_COMMANDS=$'npm install\nnpm run lint\nnpm run build'
+python worker/packet_coordinator.py
+RUN_ONCE=true python worker/execution_worker.py
+```
+
+## 5) Verify DB state after run
+
+```sql
+select id, status, started_at, completed_at, codex_branch, last_error_code, last_error
+from build_packets
+order by queued_at desc
+limit 10;
+
+select id, build_packet_id, status, failure_code, commit_sha, pr_url, pr_number, codex_exit_code
+from execution_runs
+order by started_at desc
+limit 10;
+```
+
+## 6) Definition of done for live gate
+
+- Preflight passes (`database`, `repos`, `codex`, `git`).
+- Coordinator queues at least one packet.
+- Worker completes one run (`completed` or clear terminal `failed` with reason).
+- `execution_runs` captures branch/commit/PR outputs when Codex emits result JSON.

--- a/docs/live-gate-fix-plan.md
+++ b/docs/live-gate-fix-plan.md
@@ -19,9 +19,16 @@ If you see `Network is unreachable` to the `db.<ref>.supabase.co` host, your run
 export SUPABASE_DB_URL='postgresql://<user>:<password>@<pooler-host>:6543/postgres?sslmode=require'
 ```
 
+> Do not leave placeholders like `[YOUR-PASSWORD]` in the URL.
+
 ### Validate connection
 ```bash
 make preflight
+```
+
+### Apply migrations once DB is reachable
+```bash
+make migrate
 ```
 
 ## 2) Fix repo path accessibility

--- a/sql/migrations/20260427_execution_worker.sql
+++ b/sql/migrations/20260427_execution_worker.sql
@@ -1,0 +1,49 @@
+-- Founder OS Execution Worker baseline schema
+
+create table if not exists build_packets (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references projects(id) on delete cascade,
+  task_id uuid references tasks(id) on delete set null,
+  packet_title text not null,
+  packet_body text not null,
+  target_repo text not null,
+  base_branch text not null default 'main',
+  status text not null default 'queued' check (status in ('queued', 'running', 'completed', 'failed')),
+  attempts int not null default 0,
+  max_attempts int not null default 3,
+  queued_at timestamptz not null default now(),
+  started_at timestamptz,
+  completed_at timestamptz,
+  codex_branch text,
+  validation_commands jsonb not null default '[]'::jsonb,
+  last_error text,
+  last_error_code text,
+  check (attempts >= 0),
+  check (max_attempts >= 1)
+);
+
+create table if not exists execution_runs (
+  id uuid primary key default gen_random_uuid(),
+  build_packet_id uuid not null references build_packets(id) on delete cascade,
+  project_id uuid not null references projects(id) on delete cascade,
+  task_id uuid references tasks(id) on delete set null,
+  status text not null default 'running' check (status in ('running', 'completed', 'failed')),
+  codex_prompt text not null,
+  codex_branch text not null,
+  codex_stdout text,
+  codex_stderr text,
+  codex_exit_code int,
+  commit_sha text,
+  pr_url text,
+  pr_number int,
+  failure_code text,
+  validation_results jsonb not null default '[]'::jsonb,
+  started_at timestamptz not null default now(),
+  finished_at timestamptz
+);
+
+create index if not exists idx_build_packets_status_queued_at
+  on build_packets(status, queued_at);
+
+create index if not exists idx_execution_runs_build_packet_id
+  on execution_runs(build_packet_id);

--- a/sql/migrations/20260427_execution_worker_constraints.sql
+++ b/sql/migrations/20260427_execution_worker_constraints.sql
@@ -1,0 +1,57 @@
+-- Add integrity constraints for status and retry counters.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'build_packets_status_check'
+  ) THEN
+    ALTER TABLE build_packets
+      ADD CONSTRAINT build_packets_status_check
+      CHECK (status in ('queued', 'running', 'completed', 'failed')) NOT VALID;
+    ALTER TABLE build_packets
+      VALIDATE CONSTRAINT build_packets_status_check;
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'build_packets_attempts_nonnegative_check'
+  ) THEN
+    ALTER TABLE build_packets
+      ADD CONSTRAINT build_packets_attempts_nonnegative_check
+      CHECK (attempts >= 0) NOT VALID;
+    ALTER TABLE build_packets
+      VALIDATE CONSTRAINT build_packets_attempts_nonnegative_check;
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'build_packets_max_attempts_min_one_check'
+  ) THEN
+    ALTER TABLE build_packets
+      ADD CONSTRAINT build_packets_max_attempts_min_one_check
+      CHECK (max_attempts >= 1) NOT VALID;
+    ALTER TABLE build_packets
+      VALIDATE CONSTRAINT build_packets_max_attempts_min_one_check;
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'execution_runs_status_check'
+  ) THEN
+    ALTER TABLE execution_runs
+      ADD CONSTRAINT execution_runs_status_check
+      CHECK (status in ('running', 'completed', 'failed')) NOT VALID;
+    ALTER TABLE execution_runs
+      VALIDATE CONSTRAINT execution_runs_status_check;
+  END IF;
+END
+$$;

--- a/sql/migrations/20260427_execution_worker_failure_codes.sql
+++ b/sql/migrations/20260427_execution_worker_failure_codes.sql
@@ -1,0 +1,7 @@
+-- Add failure classification fields for packet and run observability.
+
+alter table if exists build_packets
+  add column if not exists last_error_code text;
+
+alter table if exists execution_runs
+  add column if not exists failure_code text;

--- a/sql/migrations/20260427_execution_worker_retries.sql
+++ b/sql/migrations/20260427_execution_worker_retries.sql
@@ -1,0 +1,7 @@
+-- Add retry metadata for build packet processing
+
+alter table if exists build_packets
+  add column if not exists attempts int not null default 0;
+
+alter table if exists build_packets
+  add column if not exists max_attempts int not null default 3;

--- a/sql/migrations/20260427_task_review_and_packet_link.sql
+++ b/sql/migrations/20260427_task_review_and_packet_link.sql
@@ -1,0 +1,38 @@
+-- Add review/approval state and packet linkage for task -> packet queue flow.
+
+alter table if exists tasks
+  add column if not exists review_status text default 'pending';
+
+alter table if exists tasks
+  add column if not exists approved boolean default false;
+
+alter table if exists tasks
+  add column if not exists reviewed_at timestamptz;
+
+alter table if exists tasks
+  add column if not exists approved_at timestamptz;
+
+alter table if exists tasks
+  add column if not exists build_packet_id uuid references build_packets(id) on delete set null;
+
+alter table if exists tasks
+  add column if not exists packet_generated_at timestamptz;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'tasks_review_status_check'
+  ) THEN
+    ALTER TABLE tasks
+      ADD CONSTRAINT tasks_review_status_check
+      CHECK (review_status in ('pending', 'approved', 'rejected')) NOT VALID;
+    ALTER TABLE tasks
+      VALIDATE CONSTRAINT tasks_review_status_check;
+  END IF;
+END
+$$;
+
+update tasks
+   set review_status = 'approved'
+ where approved = true
+   and review_status is distinct from 'approved';

--- a/sql/migrations/20260427_task_review_and_packet_link.sql
+++ b/sql/migrations/20260427_task_review_and_packet_link.sql
@@ -7,6 +7,9 @@ alter table if exists tasks
   add column if not exists approved boolean default false;
 
 alter table if exists tasks
+  add column if not exists execution_status text;
+
+alter table if exists tasks
   add column if not exists reviewed_at timestamptz;
 
 alter table if exists tasks

--- a/sql/migrations/20260428_execution_worker_outputs.sql
+++ b/sql/migrations/20260428_execution_worker_outputs.sql
@@ -1,0 +1,10 @@
+-- Persist codex git outputs for branch/commit/PR observability.
+
+alter table if exists execution_runs
+  add column if not exists commit_sha text;
+
+alter table if exists execution_runs
+  add column if not exists pr_url text;
+
+alter table if exists execution_runs
+  add column if not exists pr_number int;

--- a/worker/apply_migrations.py
+++ b/worker/apply_migrations.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Apply Founder OS SQL migrations in filename order."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import psycopg
+
+
+def migration_files(repo_root: Path) -> list[Path]:
+    migration_dir = repo_root / "sql" / "migrations"
+    return sorted(path for path in migration_dir.glob("*.sql") if path.is_file())
+
+
+def main() -> None:
+    db_url = os.environ.get("SUPABASE_DB_URL")
+    if not db_url:
+        raise SystemExit("SUPABASE_DB_URL is required")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    files = migration_files(repo_root)
+    if not files:
+        raise SystemExit("No migration files found under sql/migrations")
+
+    with psycopg.connect(db_url) as conn:
+        conn.autocommit = False
+        with conn.cursor() as cur:
+            for file in files:
+                sql = file.read_text()
+                cur.execute(sql)
+                print(f"applied={file.relative_to(repo_root)}")
+        conn.commit()
+
+
+if __name__ == "__main__":
+    main()

--- a/worker/execution_worker.py
+++ b/worker/execution_worker.py
@@ -1,0 +1,604 @@
+#!/usr/bin/env python3
+"""Founder OS execution worker (minimum viable version).
+
+Flow:
+1) claim one queued build packet
+2) lookup project/task context
+3) generate Codex prompt + branch name
+4) execute Codex command
+5) run validation commands
+6) update build_packets, tasks, execution_runs statuses
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import psycopg
+from psycopg.rows import dict_row
+
+
+@dataclass
+class WorkerConfig:
+    db_url: str
+    poll_seconds: int = 10
+    codex_exec_command: str = "codex run --prompt-file {prompt_file} --repo {repo_path} --branch {branch}"
+    repo_root: str = "/workspace"
+    command_timeout_seconds: int = 1800
+    codex_result_json_relpath: str = ".founder_os/execution_result.json"
+    repo_map: dict[str, str] | None = None
+
+
+class PacketValidationError(ValueError):
+    """Raised when a queued build packet does not meet the worker contract."""
+
+
+class FailureCode:
+    MISSING_PROJECT = "missing_project"
+    MISSING_TASK = "missing_task"
+    INVALID_PACKET = "invalid_packet"
+    INVALID_REPO_PATH = "invalid_repo_path"
+    CODEX_FAILED = "codex_nonzero"
+    VALIDATION_FAILED = "validation_nonzero"
+    UNHANDLED = "unhandled_worker_error"
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def sanitize_slug(value: str, max_len: int = 40) -> str:
+    normalized = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip().lower()).strip("-")
+    return normalized[:max_len] or "task"
+
+
+def build_branch_name(task: dict[str, Any] | None, packet: dict[str, Any]) -> str:
+    task_part = "task"
+    if task:
+        task_part = sanitize_slug(task.get("task_title") or "task")
+        task_id = str(task["id"])[:8]
+    else:
+        task_id = str(packet["id"])[:8]
+    return f"founder-os/{task_part}-{task_id}"
+
+
+def build_codex_prompt(packet: dict[str, Any], project: dict[str, Any], task: dict[str, Any] | None, branch: str) -> str:
+    task_block = ""
+    if task:
+        task_block = (
+            f"Task Title: {task['task_title']}\n"
+            f"Task Description: {task.get('description') or 'N/A'}\n"
+            f"Task Type: {task.get('task_type') or 'N/A'}\n"
+        )
+
+    return (
+        "You are Codex acting as Founder OS execution engine.\n"
+        "Implement only what is requested in the build packet with minimal changes.\n"
+        "Do not add infrastructure not explicitly requested.\n\n"
+        f"Project: {project['project_name']}\n"
+        f"Project Summary: {project.get('summary') or 'N/A'}\n"
+        f"Target Repo: {packet['target_repo']}\n"
+        f"Base Branch: {packet['base_branch']}\n"
+        f"Execution Branch: {branch}\n\n"
+        f"Build Packet Title: {packet['packet_title']}\n"
+        f"Build Packet Body:\n{packet['packet_body']}\n\n"
+        f"{task_block}"
+        "After making changes, run requested validations, commit, and prepare PR output.\n"
+        "Write .founder_os/execution_result.json with JSON keys: branch, commit_sha, pr_url, pr_number.\n"
+    )
+
+
+def run_command(command: str, cwd: str, timeout_seconds: int) -> tuple[int, str, str]:
+    try:
+        process = subprocess.run(
+            command,
+            cwd=cwd,
+            shell=True,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+        )
+        return process.returncode, process.stdout, process.stderr
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        timeout_msg = f"Command timed out after {timeout_seconds}s"
+        stderr = f"{stderr}\n{timeout_msg}".strip()
+        return 124, stdout, stderr
+
+
+def run_codex(
+    codex_template: str,
+    prompt: str,
+    repo_path: str,
+    branch: str,
+    timeout_seconds: int,
+) -> tuple[int, str, str]:
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+        f.write(prompt)
+        prompt_file = f.name
+
+    try:
+        if "{" in codex_template and "}" in codex_template:
+            command = codex_template.format(
+                prompt_file=shlex.quote(prompt_file),
+                repo_path=shlex.quote(repo_path),
+                branch=shlex.quote(branch),
+            )
+        else:
+            command = (
+                f"{codex_template} run --prompt-file {shlex.quote(prompt_file)} "
+                f"--repo {shlex.quote(repo_path)} --branch {shlex.quote(branch)}"
+            )
+        return run_command(command, cwd=repo_path, timeout_seconds=timeout_seconds)
+    finally:
+        os.unlink(prompt_file)
+
+
+def parse_execution_result(repo_path: str, relpath: str) -> dict[str, Any]:
+    result_path = Path(repo_path) / relpath
+    if not result_path.exists():
+        return {}
+    try:
+        payload = json.loads(result_path.read_text())
+    except json.JSONDecodeError as exc:
+        raise PacketValidationError(f"Codex result JSON is invalid: {result_path}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise PacketValidationError(f"Codex result JSON must be an object: {result_path}")
+    return payload
+
+
+def validate_packet(packet: dict[str, Any]) -> None:
+    required = ["id", "project_id", "packet_title", "packet_body", "target_repo", "base_branch"]
+    missing = [key for key in required if not packet.get(key)]
+    if missing:
+        raise PacketValidationError(f"Missing required packet fields: {', '.join(missing)}")
+
+
+def parse_validation_commands(raw_commands: Any) -> list[str]:
+    if raw_commands is None:
+        return []
+    commands = raw_commands
+    if isinstance(raw_commands, str):
+        try:
+            commands = json.loads(raw_commands)
+        except json.JSONDecodeError as exc:
+            raise PacketValidationError(f"validation_commands is not valid JSON: {exc}") from exc
+    if not isinstance(commands, list) or any(not isinstance(item, str) for item in commands):
+        raise PacketValidationError("validation_commands must be a JSON array of command strings")
+    normalized = [item.strip() for item in commands]
+    if any(not item for item in normalized):
+        raise PacketValidationError("validation_commands cannot contain empty commands")
+    return normalized
+
+
+def resolve_repo_path(repo_root: str, target_repo: str, repo_map: dict[str, str] | None = None) -> str:
+    root = Path(repo_root).resolve()
+    if repo_map and target_repo in repo_map:
+        candidate = Path(repo_map[target_repo]).resolve()
+    elif Path(target_repo).is_absolute():
+        candidate = Path(target_repo).resolve()
+    else:
+        candidate = (root / target_repo).resolve()
+        if not candidate.exists() and root.exists() and (root / ".git").exists():
+            candidate = root
+
+    allowed_roots = [root]
+    if repo_map:
+        allowed_roots.extend(Path(path).resolve() for path in repo_map.values())
+
+    if not any(candidate == allowed or str(candidate).startswith(f"{allowed}{os.sep}") for allowed in allowed_roots):
+        raise PacketValidationError("target_repo must stay within REPO_ROOT or configured REPO_MAP")
+
+    if not candidate.exists():
+        raise PacketValidationError(f"target_repo path does not exist: {candidate}")
+    return str(candidate)
+
+
+def fetch_one_queued_packet(conn: psycopg.Connection[Any]) -> dict[str, Any] | None:
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """
+            select *
+            from build_packets
+            where status = 'queued'
+            order by queued_at asc
+            for update skip locked
+            limit 1
+            """
+        )
+        return cur.fetchone()
+
+
+def claim_packet(conn: psycopg.Connection[Any], packet_id: UUID) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            update build_packets
+               set status = 'running',
+                   attempts = coalesce(attempts, 0) + 1,
+                   started_at = %s,
+                   last_error = null,
+                   last_error_code = null
+             where id = %s
+            """,
+            (utc_now(), packet_id),
+        )
+
+
+def get_project_and_task(conn: psycopg.Connection[Any], packet: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute("select * from projects where id = %s", (packet["project_id"],))
+        project = cur.fetchone()
+        if not project:
+            raise ValueError(f"Project not found: {packet['project_id']}")
+
+        task = None
+        if packet.get("task_id"):
+            cur.execute("select * from tasks where id = %s", (packet["task_id"],))
+            task = cur.fetchone()
+            if not task:
+                raise ValueError(f"Task not found: {packet['task_id']}")
+        return project, task
+
+
+def create_execution_run(
+    conn: psycopg.Connection[Any],
+    packet: dict[str, Any],
+    branch: str,
+    prompt: str,
+) -> UUID:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            insert into execution_runs (build_packet_id, project_id, task_id, status, codex_prompt, codex_branch)
+            values (%s, %s, %s, 'running', %s, %s)
+            returning id
+            """,
+            (packet["id"], packet["project_id"], packet.get("task_id"), prompt, branch),
+        )
+        row = cur.fetchone()
+        return row[0]
+
+
+def update_task_status(conn: psycopg.Connection[Any], task_id: UUID | None, status: str) -> None:
+    if not task_id:
+        return
+    with conn.cursor() as cur:
+        cur.execute("update tasks set status = %s where id = %s", (status, task_id))
+
+
+def finalize_success(
+    conn: psycopg.Connection[Any],
+    packet_id: UUID,
+    run_id: UUID,
+    branch: str,
+    codex_out: str,
+    codex_err: str,
+    codex_code: int,
+    validation_results: list[dict[str, Any]],
+    commit_sha: str | None = None,
+    pr_url: str | None = None,
+    pr_number: int | None = None,
+) -> None:
+    finished_at = utc_now()
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            update build_packets
+               set status = 'completed',
+                   completed_at = %s,
+                   codex_branch = %s,
+                   last_error = null,
+                   last_error_code = null
+             where id = %s
+            """,
+            (finished_at, branch, packet_id),
+        )
+        cur.execute(
+            """
+            update execution_runs
+               set status = 'completed',
+                   finished_at = %s,
+                   failure_code = null,
+                   codex_stdout = %s,
+                   codex_stderr = %s,
+                   codex_exit_code = %s,
+                   commit_sha = %s,
+                   pr_url = %s,
+                   pr_number = %s,
+                   validation_results = %s
+             where id = %s
+            """,
+            (finished_at, codex_out, codex_err, codex_code, commit_sha, pr_url, pr_number, json.dumps(validation_results), run_id),
+        )
+
+
+def finalize_failure(
+    conn: psycopg.Connection[Any],
+    packet_id: UUID,
+    run_id: UUID,
+    err: str,
+    codex_out: str = "",
+    codex_err: str = "",
+    codex_code: int | None = None,
+    validation_results: list[dict[str, Any]] | None = None,
+    failure_code: str | None = None,
+    commit_sha: str | None = None,
+    pr_url: str | None = None,
+    pr_number: int | None = None,
+) -> None:
+    finished_at = utc_now()
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            update build_packets
+               set status = 'failed',
+                   completed_at = %s,
+                   last_error = %s,
+                   last_error_code = %s
+             where id = %s
+            """,
+            (finished_at, err[:4000], failure_code, packet_id),
+        )
+        cur.execute(
+            """
+            update execution_runs
+               set status = 'failed',
+                   finished_at = %s,
+                   failure_code = %s,
+                   codex_stdout = %s,
+                   codex_stderr = %s,
+                   codex_exit_code = %s,
+                   commit_sha = %s,
+                   pr_url = %s,
+                   pr_number = %s,
+                   validation_results = %s
+             where id = %s
+            """,
+            (
+                finished_at,
+                failure_code,
+                codex_out,
+                codex_err,
+                codex_code,
+                commit_sha,
+                pr_url,
+                pr_number,
+                json.dumps(validation_results or []),
+                run_id,
+            ),
+        )
+
+
+def requeue_packet(conn: psycopg.Connection[Any], packet_id: UUID, err: str, error_code: str | None = None) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            update build_packets
+               set status = 'queued',
+                   started_at = null,
+                   completed_at = null,
+                   last_error = %s,
+                   last_error_code = %s
+             where id = %s
+            """,
+            (err[:4000], error_code, packet_id),
+        )
+
+
+def should_retry(packet: dict[str, Any]) -> bool:
+    attempts = int(packet.get("attempts") or 0) + 1
+    raw_max_attempts = packet.get("max_attempts")
+    max_attempts = max(1, int(raw_max_attempts)) if raw_max_attempts is not None else 3
+    return attempts < max_attempts
+
+
+def run_validation_commands(commands: list[str], cwd: str, timeout_seconds: int) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for cmd in commands:
+        code, out, err = run_command(cmd, cwd, timeout_seconds=timeout_seconds)
+        results.append(
+            {
+                "command": cmd,
+                "exit_code": code,
+                "stdout": out,
+                "stderr": err,
+                "passed": code == 0,
+            }
+        )
+    return results
+
+
+def process_one_packet(config: WorkerConfig) -> bool:
+    with psycopg.connect(config.db_url) as conn:
+        conn.autocommit = False
+        packet = fetch_one_queued_packet(conn)
+        if not packet:
+            conn.commit()
+            return False
+
+        claim_packet(conn, packet["id"])
+        update_task_status(conn, packet.get("task_id"), "In Progress")
+        conn.commit()
+
+        run_id: UUID | None = None
+        try:
+            validate_packet(packet)
+            project, task = get_project_and_task(conn, packet)
+            branch = build_branch_name(task, packet)
+            prompt = build_codex_prompt(packet, project, task, branch)
+            run_id = create_execution_run(conn, packet, branch, prompt)
+            conn.commit()
+
+            repo_path = resolve_repo_path(config.repo_root, packet["target_repo"], config.repo_map)
+            codex_code, codex_out, codex_err = run_codex(
+                config.codex_exec_command,
+                prompt,
+                repo_path,
+                branch,
+                timeout_seconds=config.command_timeout_seconds,
+            )
+
+            commands = parse_validation_commands(packet.get("validation_commands"))
+            validation_results = run_validation_commands(
+                commands,
+                cwd=repo_path,
+                timeout_seconds=config.command_timeout_seconds,
+            )
+            validations_ok = all(item["passed"] for item in validation_results)
+            execution_result = parse_execution_result(repo_path, config.codex_result_json_relpath)
+            result_branch = execution_result.get("branch") or branch
+            result_commit_sha = execution_result.get("commit_sha")
+            result_pr_url = execution_result.get("pr_url")
+            result_pr_number = execution_result.get("pr_number")
+
+            if codex_code == 0 and validations_ok:
+                finalize_success(
+                    conn,
+                    packet["id"],
+                    run_id,
+                    result_branch,
+                    codex_out,
+                    codex_err,
+                    codex_code,
+                    validation_results,
+                    commit_sha=result_commit_sha,
+                    pr_url=result_pr_url,
+                    pr_number=result_pr_number,
+                )
+                update_task_status(conn, packet.get("task_id"), "Review")
+            else:
+                reason = "Codex execution failed" if codex_code != 0 else "Validation commands failed"
+                if should_retry(packet):
+                    finalize_failure(
+                        conn,
+                        packet["id"],
+                        run_id,
+                        err=f"Attempt failed (will retry): {reason}",
+                        codex_out=codex_out,
+                        codex_err=codex_err,
+                        codex_code=codex_code,
+                        validation_results=validation_results,
+                        failure_code=FailureCode.CODEX_FAILED if codex_code != 0 else FailureCode.VALIDATION_FAILED,
+                        commit_sha=result_commit_sha,
+                        pr_url=result_pr_url,
+                        pr_number=result_pr_number,
+                    )
+                    requeue_packet(
+                        conn,
+                        packet["id"],
+                        err=reason,
+                        error_code=FailureCode.CODEX_FAILED if codex_code != 0 else FailureCode.VALIDATION_FAILED,
+                    )
+                else:
+                    finalize_failure(
+                        conn,
+                        packet["id"],
+                        run_id,
+                        err=reason,
+                        codex_out=codex_out,
+                        codex_err=codex_err,
+                        codex_code=codex_code,
+                        validation_results=validation_results,
+                        failure_code=FailureCode.CODEX_FAILED if codex_code != 0 else FailureCode.VALIDATION_FAILED,
+                        commit_sha=result_commit_sha,
+                        pr_url=result_pr_url,
+                        pr_number=result_pr_number,
+                    )
+                    update_task_status(conn, packet.get("task_id"), "Blocked")
+
+            conn.commit()
+            return True
+        except Exception as exc:  # noqa: BLE001
+            message = str(exc)
+            if isinstance(exc, PacketValidationError):
+                code = FailureCode.INVALID_PACKET
+                if "target_repo" in message:
+                    code = FailureCode.INVALID_REPO_PATH
+            elif isinstance(exc, ValueError) and message.startswith("Project not found"):
+                code = FailureCode.MISSING_PROJECT
+            elif isinstance(exc, ValueError) and message.startswith("Task not found"):
+                code = FailureCode.MISSING_TASK
+            else:
+                code = FailureCode.UNHANDLED
+
+            if run_id:
+                if should_retry(packet):
+                    finalize_failure(
+                        conn,
+                        packet["id"],
+                        run_id,
+                        err=f"Attempt failed (will retry): {exc}",
+                        failure_code=code,
+                    )
+                    requeue_packet(conn, packet["id"], err=f"Unhandled worker error: {exc}", error_code=code)
+                else:
+                    finalize_failure(
+                        conn,
+                        packet["id"],
+                        run_id,
+                        err=f"Unhandled worker error: {exc}",
+                        failure_code=code,
+                    )
+                    update_task_status(conn, packet.get("task_id"), "Blocked")
+                conn.commit()
+            else:
+                with conn.cursor() as cur:
+                    err = f"Worker setup failure: {exc}"
+                    if should_retry(packet):
+                        cur.execute(
+                            "update build_packets set status = 'queued', last_error = %s, last_error_code = %s where id = %s",
+                            (f"Attempt failed (will retry): {err}"[:4000], code, packet["id"]),
+                        )
+                    else:
+                        cur.execute(
+                            "update build_packets set status = 'failed', last_error = %s, last_error_code = %s where id = %s",
+                            (err[:4000], code, packet["id"]),
+                        )
+                        update_task_status(conn, packet.get("task_id"), "Blocked")
+                conn.commit()
+            return True
+
+
+def main() -> None:
+    db_url = os.environ.get("SUPABASE_DB_URL")
+    if not db_url:
+        raise SystemExit("SUPABASE_DB_URL is required")
+
+    config = WorkerConfig(
+        db_url=db_url,
+        poll_seconds=int(os.environ.get("WORKER_POLL_SECONDS", "10")),
+        codex_exec_command=os.environ.get(
+            "CODEX_EXEC_COMMAND",
+            "codex run --prompt-file {prompt_file} --repo {repo_path} --branch {branch}",
+        ),
+        repo_root=os.environ.get("REPO_ROOT", "/workspace"),
+        command_timeout_seconds=int(os.environ.get("COMMAND_TIMEOUT_SECONDS", "1800")),
+        codex_result_json_relpath=os.environ.get("CODEX_RESULT_JSON_RELPATH", ".founder_os/execution_result.json"),
+        repo_map=json.loads(os.environ.get("REPO_MAP_JSON", "{}")) if os.environ.get("REPO_MAP_JSON") else None,
+    )
+
+    run_once = os.environ.get("RUN_ONCE", "false").lower() == "true"
+    while True:
+        handled = process_one_packet(config)
+        if run_once:
+            return
+        if not handled:
+            time.sleep(config.poll_seconds)
+
+
+if __name__ == "__main__":
+    main()

--- a/worker/live_gate_preflight.py
+++ b/worker/live_gate_preflight.py
@@ -12,6 +12,8 @@ import psycopg
 
 
 def check_db(url: str) -> tuple[bool, str]:
+    if "[YOUR-PASSWORD]" in url or "<password>" in url.lower():
+        return False, "database URL still contains a password placeholder"
     try:
         with psycopg.connect(url) as conn:
             with conn.cursor() as cur:

--- a/worker/live_gate_preflight.py
+++ b/worker/live_gate_preflight.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Preflight checks before running Founder OS coordinator/worker in a live environment."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+
+import psycopg
+
+
+def check_db(url: str) -> tuple[bool, str]:
+    try:
+        with psycopg.connect(url) as conn:
+            with conn.cursor() as cur:
+                cur.execute("select 1")
+                cur.fetchone()
+        return True, "database connection OK"
+    except Exception as exc:  # noqa: BLE001
+        return False, f"database connection failed: {exc}"
+
+
+def check_repo_paths(repo_root: str, repo_map_raw: str | None) -> tuple[bool, str]:
+    missing: list[str] = []
+    root = Path(repo_root)
+    if not root.exists():
+        missing.append(str(root))
+
+    if repo_map_raw:
+        try:
+            repo_map = json.loads(repo_map_raw)
+        except json.JSONDecodeError as exc:
+            return False, f"REPO_MAP_JSON is invalid JSON: {exc}"
+        for name, path in repo_map.items():
+            if not Path(path).exists():
+                missing.append(f"{name}:{path}")
+
+    if missing:
+        return False, f"missing repo paths: {', '.join(missing)}"
+    return True, "repo paths OK"
+
+
+def check_binary(name: str) -> tuple[bool, str]:
+    if shutil.which(name):
+        return True, f"{name} found"
+    return False, f"{name} not found in PATH"
+
+
+def main() -> None:
+    db_url = os.environ.get("SUPABASE_DB_URL")
+    if not db_url:
+        raise SystemExit("SUPABASE_DB_URL is required")
+
+    repo_root = os.environ.get("REPO_ROOT", "/workspace")
+    repo_map_raw = os.environ.get("REPO_MAP_JSON")
+    codex_command = os.environ.get("CODEX_EXEC_COMMAND", "codex")
+    codex_binary = codex_command.split()[0]
+
+    checks = [
+        ("database", *check_db(db_url)),
+        ("repos", *check_repo_paths(repo_root, repo_map_raw)),
+        ("codex", *check_binary(codex_binary)),
+        ("git", *check_binary("git")),
+    ]
+
+    failures = [name for name, ok, _ in checks if not ok]
+    for name, ok, detail in checks:
+        status = "PASS" if ok else "FAIL"
+        print(f"[{status}] {name}: {detail}")
+
+    if failures:
+        raise SystemExit(f"Preflight failed: {', '.join(failures)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/worker/packet_coordinator.py
+++ b/worker/packet_coordinator.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Founder OS queue coordinator.
+
+Queues build packets for approved tasks so the execution worker can process them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import psycopg
+from psycopg.rows import dict_row
+
+
+@dataclass
+class CoordinatorConfig:
+    db_url: str
+    default_target_repo: str
+    default_base_branch: str = "main"
+    default_validation_commands: list[str] | None = None
+    batch_size: int = 25
+
+
+class CoordinatorError(ValueError):
+    """Raised when the coordinator cannot produce a valid build packet."""
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def parse_validation_commands_env(raw_value: str | None) -> list[str]:
+    if not raw_value:
+        return []
+    if "\n" in raw_value and not raw_value.strip().startswith("["):
+        commands = [line.strip() for line in raw_value.splitlines() if line.strip()]
+        return commands
+    try:
+        parsed = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise CoordinatorError(f"DEFAULT_VALIDATION_COMMANDS must be JSON: {exc}") from exc
+
+    if not isinstance(parsed, list) or any(not isinstance(item, str) for item in parsed):
+        raise CoordinatorError("DEFAULT_VALIDATION_COMMANDS must be a JSON array of strings")
+
+    commands = [item.strip() for item in parsed]
+    if any(not item for item in commands):
+        raise CoordinatorError("DEFAULT_VALIDATION_COMMANDS cannot contain blank commands")
+    return commands
+
+
+def derive_target_repo(project_repo_link: str | None, fallback_repo: str) -> str:
+    if project_repo_link:
+        link = project_repo_link.strip()
+        github_match = re.match(r"https://github\.com/[^/]+/([^/.]+)(?:\.git)?/?$", link)
+        if github_match:
+            return github_match.group(1)
+        if link and not link.startswith("http"):
+            return link
+    if not fallback_repo:
+        raise CoordinatorError("DEFAULT_TARGET_REPO is required when project.repo_link is missing")
+    return fallback_repo
+
+
+def build_packet_body(task: dict[str, Any]) -> str:
+    description = task.get("description") or "No description provided."
+    return (
+        f"Project: {task['project_name']}\n"
+        f"Task: {task['task_title']}\n\n"
+        f"Implementation requirements:\n{description}\n"
+    )
+
+
+def fetch_approved_tasks(conn: psycopg.Connection[Any], batch_size: int) -> list[dict[str, Any]]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            select column_name
+              from information_schema.columns
+             where table_schema = 'public'
+               and table_name = 'tasks'
+               and column_name in ('approved', 'review_status', 'build_packet_id')
+            """
+        )
+        columns = {row[0] for row in cur.fetchall()}
+
+    approval_filter = "coalesce(t.review_status, 'pending') = 'approved'"
+    if "approved" in columns:
+        approval_filter = "coalesce(t.approved, false) = true"
+
+    packet_link_filter = "true"
+    if "build_packet_id" in columns:
+        packet_link_filter = "t.build_packet_id is null"
+
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            f"""
+            select t.*, p.project_name, p.repo_link
+              from tasks t
+              join projects p on p.id = t.project_id
+             where {approval_filter}
+               and {packet_link_filter}
+             order by t.created_at asc
+             for update of t skip locked
+             limit %s
+            """,
+            (batch_size,),
+        )
+        return list(cur.fetchall())
+
+
+def queue_task_packet(conn: psycopg.Connection[Any], task: dict[str, Any], config: CoordinatorConfig) -> str:
+    target_repo = derive_target_repo(task.get("repo_link"), config.default_target_repo)
+    packet_body = build_packet_body(task)
+    validation_commands = config.default_validation_commands or []
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            insert into build_packets (
+              project_id,
+              task_id,
+              packet_title,
+              packet_body,
+              target_repo,
+              base_branch,
+              validation_commands,
+              status,
+              queued_at
+            )
+            values (%s, %s, %s, %s, %s, %s, %s::jsonb, 'queued', %s)
+            returning id
+            """,
+            (
+                task["project_id"],
+                task["id"],
+                task["task_title"],
+                packet_body,
+                target_repo,
+                config.default_base_branch,
+                json.dumps(validation_commands),
+                utc_now(),
+            ),
+        )
+        packet_id = str(cur.fetchone()[0])
+
+        cur.execute(
+            """
+            select column_name
+              from information_schema.columns
+             where table_schema = 'public'
+               and table_name = 'tasks'
+               and column_name in ('build_packet_id', 'packet_generated_at', 'status')
+            """
+        )
+        columns = {row[0] for row in cur.fetchall()}
+
+        set_parts: list[str] = []
+        params: list[Any] = []
+        if "build_packet_id" in columns:
+            set_parts.append("build_packet_id = %s")
+            params.append(packet_id)
+        if "packet_generated_at" in columns:
+            set_parts.append("packet_generated_at = %s")
+            params.append(utc_now())
+        if "status" in columns:
+            set_parts.append("status = 'Queued'")
+
+        if set_parts:
+            params.append(task["id"])
+            cur.execute(f"update tasks set {', '.join(set_parts)} where id = %s", params)
+
+    return packet_id
+
+
+def queue_approved_tasks(config: CoordinatorConfig) -> int:
+    queued_count = 0
+    with psycopg.connect(config.db_url) as conn:
+        conn.autocommit = False
+        tasks = fetch_approved_tasks(conn, config.batch_size)
+        for task in tasks:
+            queue_task_packet(conn, task, config)
+            queued_count += 1
+        conn.commit()
+    return queued_count
+
+
+def main() -> None:
+    db_url = os.environ.get("SUPABASE_DB_URL")
+    if not db_url:
+        raise SystemExit("SUPABASE_DB_URL is required")
+
+    config = CoordinatorConfig(
+        db_url=db_url,
+        default_target_repo=os.environ.get("DEFAULT_TARGET_REPO", ""),
+        default_base_branch=os.environ.get("DEFAULT_BASE_BRANCH", "main"),
+        default_validation_commands=parse_validation_commands_env(os.environ.get("DEFAULT_VALIDATION_COMMANDS")),
+        batch_size=int(os.environ.get("COORDINATOR_BATCH_SIZE", "25")),
+    )
+
+    queued = queue_approved_tasks(config)
+    print(f"queued_packets={queued}")
+
+
+if __name__ == "__main__":
+    main()

--- a/worker/packet_coordinator.py
+++ b/worker/packet_coordinator.py
@@ -76,6 +76,19 @@ def build_packet_body(task: dict[str, Any]) -> str:
     )
 
 
+def build_task_filters(columns: set[str]) -> tuple[str, str]:
+    approval_filter = "coalesce(t.review_status, 'pending') = 'approved'"
+    if "approved" in columns:
+        approval_filter = "coalesce(t.approved, false) = true"
+    elif "execution_status" in columns:
+        approval_filter = "coalesce(t.execution_status, '') in ('Queued', 'Approved')"
+
+    packet_link_filter = "true"
+    if "build_packet_id" in columns:
+        packet_link_filter = "t.build_packet_id is null"
+    return approval_filter, packet_link_filter
+
+
 def fetch_approved_tasks(conn: psycopg.Connection[Any], batch_size: int) -> list[dict[str, Any]]:
     with conn.cursor() as cur:
         cur.execute(
@@ -84,18 +97,12 @@ def fetch_approved_tasks(conn: psycopg.Connection[Any], batch_size: int) -> list
               from information_schema.columns
              where table_schema = 'public'
                and table_name = 'tasks'
-               and column_name in ('approved', 'review_status', 'build_packet_id')
+               and column_name in ('approved', 'review_status', 'execution_status', 'build_packet_id')
             """
         )
         columns = {row[0] for row in cur.fetchall()}
 
-    approval_filter = "coalesce(t.review_status, 'pending') = 'approved'"
-    if "approved" in columns:
-        approval_filter = "coalesce(t.approved, false) = true"
-
-    packet_link_filter = "true"
-    if "build_packet_id" in columns:
-        packet_link_filter = "t.build_packet_id is null"
+    approval_filter, packet_link_filter = build_task_filters(columns)
 
     with conn.cursor(row_factory=dict_row) as cur:
         cur.execute(
@@ -155,7 +162,7 @@ def queue_task_packet(conn: psycopg.Connection[Any], task: dict[str, Any], confi
               from information_schema.columns
              where table_schema = 'public'
                and table_name = 'tasks'
-               and column_name in ('build_packet_id', 'packet_generated_at', 'status')
+               and column_name in ('build_packet_id', 'packet_generated_at', 'status', 'execution_status')
             """
         )
         columns = {row[0] for row in cur.fetchall()}
@@ -170,6 +177,8 @@ def queue_task_packet(conn: psycopg.Connection[Any], task: dict[str, Any], confi
             params.append(utc_now())
         if "status" in columns:
             set_parts.append("status = 'Queued'")
+        if "execution_status" in columns:
+            set_parts.append("execution_status = 'Queued'")
 
         if set_parts:
             params.append(task["id"])

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -1,0 +1,1 @@
+psycopg[binary]>=3.2

--- a/worker/smoke_test.sql
+++ b/worker/smoke_test.sql
@@ -1,0 +1,53 @@
+-- Founder OS worker smoke test
+-- Replace IDs and repo path placeholders before running.
+
+-- 1) ensure a task exists for the project (optional)
+-- insert into tasks (project_id, task_title, description, status)
+-- values ('<project_uuid>', 'Smoke test execution task', 'Validate worker end-to-end', 'New')
+-- returning id;
+
+-- 1b) approve one task for packet generation
+-- update tasks
+--    set review_status = 'approved',
+--        approved_at = now()
+--  where id = '<task_uuid>';
+
+-- 2) enqueue one packet
+insert into build_packets (
+  project_id,
+  task_id,
+  packet_title,
+  packet_body,
+  target_repo,
+  base_branch,
+  max_attempts,
+  validation_commands
+) values (
+  '<project_uuid>',
+  null,
+  'Smoke test packet',
+  'Create or update a small README note so we can validate execution flow.',
+  '<repo-folder-under-REPO_ROOT>',
+  'main',
+  2,
+  '["git status --short"]'::jsonb
+)
+returning id, status, queued_at;
+
+-- 3) watch queue state
+select id, status, started_at, completed_at, codex_branch, last_error_code, last_error
+from build_packets
+order by queued_at desc
+limit 5;
+
+-- 3b) verify task linkage
+select id, status, review_status, build_packet_id, packet_generated_at
+from tasks
+order by created_at desc
+limit 5;
+
+-- 4) inspect execution run details
+select id, build_packet_id, status, failure_code, commit_sha, pr_url, pr_number, codex_exit_code, started_at, finished_at
+from execution_runs
+order by started_at desc
+limit 5;

--- a/worker/test_execution_worker.py
+++ b/worker/test_execution_worker.py
@@ -1,0 +1,98 @@
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+if "psycopg" not in sys.modules:
+    fake_psycopg = types.ModuleType("psycopg")
+    fake_psycopg.Connection = object
+    rows_module = types.ModuleType("psycopg.rows")
+    rows_module.dict_row = object()
+    fake_psycopg.rows = rows_module
+    fake_psycopg.connect = lambda *args, **kwargs: None
+    sys.modules["psycopg"] = fake_psycopg
+    sys.modules["psycopg.rows"] = rows_module
+
+from execution_worker import (
+    PacketValidationError,
+    parse_execution_result,
+    parse_validation_commands,
+    resolve_repo_path,
+    should_retry,
+)
+
+
+class ExecutionWorkerUnitTests(unittest.TestCase):
+    def test_parse_validation_commands_accepts_list(self):
+        commands = parse_validation_commands(["npm test", "npm run lint"])
+        self.assertEqual(commands, ["npm test", "npm run lint"])
+
+    def test_parse_validation_commands_accepts_json_string(self):
+        raw = json.dumps(["pytest -q"])
+        commands = parse_validation_commands(raw)
+        self.assertEqual(commands, ["pytest -q"])
+
+    def test_parse_validation_commands_rejects_invalid_shape(self):
+        with self.assertRaises(PacketValidationError):
+            parse_validation_commands({"bad": "shape"})
+
+    def test_parse_validation_commands_rejects_empty_values(self):
+        with self.assertRaises(PacketValidationError):
+            parse_validation_commands(["pytest", "   "])
+
+    def test_should_retry_true_before_max(self):
+        packet = {"attempts": 0, "max_attempts": 3}
+        self.assertTrue(should_retry(packet))
+
+    def test_should_retry_false_at_max(self):
+        packet = {"attempts": 2, "max_attempts": 3}
+        self.assertFalse(should_retry(packet))
+
+    def test_should_retry_guards_invalid_max_attempts(self):
+        packet = {"attempts": 0, "max_attempts": 0}
+        self.assertFalse(should_retry(packet))
+
+    def test_resolve_repo_path_requires_existing_nested_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            repo = root / "my-repo"
+            repo.mkdir()
+
+            resolved = resolve_repo_path(str(root), "my-repo")
+            self.assertEqual(resolved, str(repo.resolve()))
+
+    def test_resolve_repo_path_rejects_path_traversal(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            with self.assertRaises(PacketValidationError):
+                resolve_repo_path(str(root), "../escape")
+
+    def test_resolve_repo_path_supports_repo_map(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "root"
+            mapped = Path(tmpdir) / "mapped"
+            root.mkdir()
+            mapped.mkdir()
+            resolved = resolve_repo_path(str(root), "AFDP", {"AFDP": str(mapped)})
+            self.assertEqual(resolved, str(mapped.resolve()))
+
+    def test_parse_execution_result_returns_empty_when_missing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = parse_execution_result(tmpdir, ".founder_os/execution_result.json")
+            self.assertEqual(result, {})
+
+    def test_parse_execution_result_reads_json_payload(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result_file = Path(tmpdir) / ".founder_os" / "execution_result.json"
+            result_file.parent.mkdir(parents=True, exist_ok=True)
+            result_file.write_text('{"branch":"founder-os/a","commit_sha":"abc123","pr_url":"https://github.com/acme/x/pull/1","pr_number":1}')
+            result = parse_execution_result(tmpdir, ".founder_os/execution_result.json")
+            self.assertEqual(result["pr_number"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/worker/test_packet_coordinator.py
+++ b/worker/test_packet_coordinator.py
@@ -12,7 +12,7 @@ if "psycopg" not in sys.modules:
     sys.modules["psycopg"] = fake_psycopg
     sys.modules["psycopg.rows"] = rows_module
 
-from packet_coordinator import CoordinatorError, derive_target_repo, parse_validation_commands_env
+from packet_coordinator import CoordinatorError, build_task_filters, derive_target_repo, parse_validation_commands_env
 
 
 class PacketCoordinatorTests(unittest.TestCase):
@@ -36,6 +36,15 @@ class PacketCoordinatorTests(unittest.TestCase):
 
     def test_derive_target_repo_falls_back(self):
         self.assertEqual(derive_target_repo(None, "workspace-repo"), "workspace-repo")
+
+    def test_build_task_filters_prefers_approved_boolean(self):
+        approval_filter, packet_filter = build_task_filters({"approved", "build_packet_id"})
+        self.assertIn("t.approved", approval_filter)
+        self.assertEqual(packet_filter, "t.build_packet_id is null")
+
+    def test_build_task_filters_supports_execution_status(self):
+        approval_filter, _ = build_task_filters({"execution_status"})
+        self.assertIn("t.execution_status", approval_filter)
 
 
 if __name__ == "__main__":

--- a/worker/test_packet_coordinator.py
+++ b/worker/test_packet_coordinator.py
@@ -1,0 +1,42 @@
+import sys
+import types
+import unittest
+
+if "psycopg" not in sys.modules:
+    fake_psycopg = types.ModuleType("psycopg")
+    fake_psycopg.Connection = object
+    rows_module = types.ModuleType("psycopg.rows")
+    rows_module.dict_row = object()
+    fake_psycopg.rows = rows_module
+    fake_psycopg.connect = lambda *args, **kwargs: None
+    sys.modules["psycopg"] = fake_psycopg
+    sys.modules["psycopg.rows"] = rows_module
+
+from packet_coordinator import CoordinatorError, derive_target_repo, parse_validation_commands_env
+
+
+class PacketCoordinatorTests(unittest.TestCase):
+    def test_parse_validation_commands_env_valid(self):
+        commands = parse_validation_commands_env('["pytest -q", "npm run lint"]')
+        self.assertEqual(commands, ["pytest -q", "npm run lint"])
+
+    def test_parse_validation_commands_env_rejects_blank(self):
+        with self.assertRaises(CoordinatorError):
+            parse_validation_commands_env('["pytest -q", " "]')
+
+    def test_parse_validation_commands_env_accepts_multiline(self):
+        commands = parse_validation_commands_env("npm install\nnpm run lint\nnpm run build")
+        self.assertEqual(commands, ["npm install", "npm run lint", "npm run build"])
+
+    def test_derive_target_repo_from_github_url(self):
+        self.assertEqual(
+            derive_target_repo("https://github.com/acme/founder-os.git", "fallback"),
+            "founder-os",
+        )
+
+    def test_derive_target_repo_falls_back(self):
+        self.assertEqual(derive_target_repo(None, "workspace-repo"), "workspace-repo")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a minimal execution worker to claim queued build packets, run a Codex-driven implementation, run validations, and update task/packet status.
- Add a coordinator to enqueue approved tasks into the `build_packets` queue and derive packet defaults for execution.
- Persist execution observability and retry metadata in the database to support reliable requeues and failure classification.

### Description
- Add a new execution worker implementation in `worker/execution_worker.py` that claims `build_packets`, creates `execution_runs`, runs Codex and validation commands, and updates statuses and failure codes.
- Add a queue coordinator in `worker/packet_coordinator.py` to generate `build_packets` from approved `tasks` and configurable defaults, plus `worker/smoke_test.sql` and `worker/requirements.txt` for setup.
- Add SQL schema and migrations under `sql/migrations/*` to create `build_packets` and `execution_runs`, add retry counters, failure fields, output fields, and task review/packet linkage constraints.
- Add unit tests `worker/test_execution_worker.py` and `worker/test_packet_coordinator.py`, Makefile targets (`queue-approved-tasks`, `worker-once`, `worker-loop`, `test-worker`), and update `README.md` with setup/run instructions and worker contract details.

### Testing
- Ran unit tests `python -m unittest worker/test_execution_worker.py` which passed.
- Ran unit tests `python -m unittest worker/test_packet_coordinator.py` which passed.
- Ran quick static checks referenced in the README (`python -m py_compile worker/execution_worker.py` and `python -m py_compile worker/packet_coordinator.py`) as part of validation steps, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb76e132083318ed5dbc676e97317)